### PR TITLE
Empty vite output directory on every build.

### DIFF
--- a/ViteDotNet/Plugin/src/index.ts
+++ b/ViteDotNet/Plugin/src/index.ts
@@ -49,7 +49,7 @@ function ViteDotNet(config: PluginConfig) {
         },
         build: {
           outDir: `../wwwroot`,
-          emptyOutDir: false,
+          emptyOutDir: true,
           manifest: `${config.appFolder}/manifest.json`,
           rollupOptions: {
             // overwrite default .html entry


### PR DESCRIPTION
I'm using Vite.NET with Vue (but I guess the same behavior is reproducible not only for Vue because it does not seem to be dependant on it all) and noticed that new files are added in wwwroot/ClientApp on every "npm run build" instead of replacing old ones.

It's easy to reproduce:
- Create ClientApp with some default components and run "npm run build". Check that wwwroot/ClientApp contains, for example, main.c46d65a4.js.
- Make some change in components (it's enough just to add letter to some string for example) and save it.
- Run "npm run build". Check wwwroot/ClientApp, it will contain previously created main.c46d65a4.js and new one like main.c118e38f.js.
Expected behavior: wwwroot/ClientApp must contain only main.c118e38f.js, old file must be deleted.

Since "npm run build" is not needed very often then I guess there is no problem to set "emptyOutDir: true" and allow Vite to do all job.