### PR TITLE
ViteDotNetPlugin type fix to get rid of typescript error.

### DIFF
--- a/ViteDotNet/Plugin/src/index.ts
+++ b/ViteDotNet/Plugin/src/index.ts
@@ -10,7 +10,7 @@ export type PluginConfig = {
 
 function outputOptions (assetsDir: string) {
   // Internal: Avoid nesting entrypoints unnecessarily.
-  const outputFileName = (ext: string) => ({ name }: { name: string }) => {
+  const outputFileName = (ext: string) => ({ name }: { name: string | undefined }) => {
     const shortName = basename(name).split('.')[0]
     return posix.join(assetsDir, `${shortName}.[hash].${ext}`)
   }


### PR DESCRIPTION
Plugin call ViteDotNet("src/main.ts", 5173, "ClientApp") causes TypeScript 5.2.2 to show next validation error:
```
TS2769	(TS) No overload matches this call.
  The last overload gave the following error.
    Type '{ name: string; enforce: "post"; config: (userConfig: UserConfig) => { server: { origin: string; port: number; strictPort: boolean; hmr: { protocol: string; }; }; build: { outDir: string; emptyOutDir: boolean; manifest: string; rollupOptions: { ...; }; }; }; }' is not assignable to type 'PluginOption'.
      Type '{ name: string; enforce: "post"; config: (userConfig: UserConfig) => { server: { origin: string; port: number; strictPort: boolean; hmr: { protocol: string; }; }; build: { outDir: string; emptyOutDir: boolean; manifest: string; rollupOptions: { ...; }; }; }; }' is not assignable to type 'Plugin_2'.
        Types of property 'config' are incompatible.
          Type '(userConfig: UserConfig) => { server: { origin: string; port: number; strictPort: boolean; hmr: { protocol: string; }; }; build: { outDir: string; emptyOutDir: boolean; manifest: string; rollupOptions: { ...; }; }; }' is not assignable to type 'ObjectHook<(this: void, config: UserConfig, env: ConfigEnv) => void | UserConfig | Promise<void | UserConfig | null> | null> | undefined'.
            Type '(userConfig: UserConfig) => { server: { origin: string; port: number; strictPort: boolean; hmr: { protocol: string; }; }; build: { outDir: string; emptyOutDir: boolean; manifest: string; rollupOptions: { ...; }; }; }' is not assignable to type '(this: void, config: UserConfig, env: ConfigEnv) => void | UserConfig | Promise<void | UserConfig | null> | null'.
              Type '{ server: { origin: string; port: number; strictPort: boolean; hmr: { protocol: string; }; }; build: { outDir: string; emptyOutDir: boolean; manifest: string; rollupOptions: { input: string; output: { entryFileNames: ({ name }: { ...; }) => string; chunkFileNames: ({ name }: { ...; }) => string; assetFileNames: ({ n...' is not assignable to type 'void | UserConfig | Promise<void | UserConfig | null> | null'.
                Type '{ server: { origin: string; port: number; strictPort: boolean; hmr: { protocol: string; }; }; build: { outDir: string; emptyOutDir: boolean; manifest: string; rollupOptions: { input: string; output: { entryFileNames: ({ name }: { ...; }) => string; chunkFileNames: ({ name }: { ...; }) => string; assetFileNames: ({ n...' is not assignable to type 'UserConfig'.
                  The types of 'build.rollupOptions.output' are incompatible between these types.
                    Type '{ entryFileNames: ({ name }: { name: string; }) => string; chunkFileNames: ({ name }: { name: string; }) => string; assetFileNames: ({ name }: { name: string; }) => string; }' is not assignable to type 'OutputOptions | OutputOptions[] | undefined'.
                      Type '{ entryFileNames: ({ name }: { name: string; }) => string; chunkFileNames: ({ name }: { name: string; }) => string; assetFileNames: ({ name }: { name: string; }) => string; }' is not assignable to type 'OutputOptions'.
                        Types of property 'assetFileNames' are incompatible.
                          Type '({ name }: { name: string; }) => string' is not assignable to type 'string | ((chunkInfo: PreRenderedAsset) => string) | undefined'.
                            Type '({ name }: { name: string; }) => string' is not assignable to type '(chunkInfo: PreRenderedAsset) => string'.
                              Types of parameters '__0' and 'chunkInfo' are incompatible.
                                Type 'PreRenderedAsset' is not assignable to type '{ name: string; }'.
                                  Types of property 'name' are incompatible.
                                    Type 'string | undefined' is not assignable to type 'string'.
                                      Type 'undefined' is not assignable to type 'string'.
```
Everything seems to work but likely better to try to get rid of this error.

Please check, I guess my fix is relevant because Vite type has next definition:
```
export interface PreRenderedAsset {
	name: string | undefined;
	source: string | Uint8Array;
	type: 'asset';
}
```
At least I tested it when manually edited index.d.ts which comes with vite-dotnet npm module replacing
```
output: {
		entryFileNames: ({ name }: {
			name: string;
		}) => string;
		chunkFileNames: ({ name }: {
			name: string;
		}) => string;
		assetFileNames: ({ name }: {
			name: string;
		}) => string;
	};
```
with
```
output: {
		entryFileNames: ({ name }: {
			name: string | undefined;
		}) => string;
		chunkFileNames: ({ name }: {
			name: string | undefined;
		}) => string;
		assetFileNames: ({ name }: {
			name: string | undefined;
		}) => string;
	};
```
and it solved the issue.