### PR TITLE
ProductionViteSpaScripts.cshtml path fixes.

### DIFF
--- a/ViteDotNet/Views/ViteDotNet/ProductionViteSpaScripts.cshtml
+++ b/ViteDotNet/Views/ViteDotNet/ProductionViteSpaScripts.cshtml
@@ -16,11 +16,11 @@ else
     {
         foreach (var css in Model.AppManifest.css)
         {
-            @: <link rel="stylesheet" href="@css" />
+            @: <link rel="stylesheet" href="/@css" />
         }
     }
 
-    <script type="module" src="@jsBundle"></script>
+    <script type="module" src="/@jsBundle"></script>
 
     <div id="@Model.IntegrationConfig.ContainerElementId"></div>
 }


### PR DESCRIPTION
Some issue in paths for css and scripts in ProductionViteSpaScripts.cshtml.

How did I find it:
- For the sake of test I created SPA with root in https://localhost:7104/admin/, but from my understanding it's not needed to have even SPA located in nested address, it's enough just to create any nested page in single SPA, for example https://localhost:7104/users/profile. Of course it's needed to setup Fallback like `app.MapFallbackToPage("/{*catchall}", "/Index") `. Now when you go to this address and refresh page then page is opened but scripts are not loaded because they are tried to be loaded from addresses like:
https://localhost:7104/admin/AdminApp/main.228761a0.js
https://localhost:7104/admin/AdminApp/main.951a8be3.css
i.e. file paths are relative to current address (https://localhost:7104/admin/) instead of root (https://localhost:7104/). Correct paths are:
https://localhost:7104/AdminApp/main.228761a0.js
https://localhost:7104/AdminApp/main.951a8be3.css

Changes are supposed to fix it. Honestly I'm not 100% sure that it's fully correct fix for all environments. I had idea to use Environment.WebRootPath but have doubts (there was mix of forward slashes and backslashes). So if you see more appropriate way to fix that then please do:).